### PR TITLE
Version settings-security model independently of JAR (impl/spec version)

### DIFF
--- a/src/main/java/org/codehaus/plexus/components/secdispatcher/internal/SecUtil.java
+++ b/src/main/java/org/codehaus/plexus/components/secdispatcher/internal/SecUtil.java
@@ -110,7 +110,9 @@ public final class SecUtil {
         Path tempFile = parent.resolve(target.getFileName() + "."
                 + Long.toUnsignedString(ThreadLocalRandom.current().nextLong()) + ".tmp");
 
-        configuration.setModelVersion(specVersion());
+        // always set manually as some features don't require changes in the underlying model but still require
+        // adjustments of either minor or major version of the JAR
+        configuration.setModelVersion("4.0");
         configuration.setModelEncoding(StandardCharsets.UTF_8.name());
 
         try {

--- a/src/test/java/org/codehaus/plexus/components/secdispatcher/internal/SecUtilTest.java
+++ b/src/test/java/org/codehaus/plexus/components/secdispatcher/internal/SecUtilTest.java
@@ -68,7 +68,7 @@ public class SecUtilTest {
         Path path = Path.of("./target/sec.xml");
         SettingsSecurity config = SecUtil.read(path);
         assertNotNull(config);
-        assertEquals(SecUtil.specVersion(), config.getModelVersion());
+        assertEquals("4.0", config.getModelVersion());
         assertEquals(StandardCharsets.UTF_8.name(), config.getModelEncoding());
         assertEquals("magic:mighty", config.getDefaultDispatcher());
         SecUtil.write(path, config, false);
@@ -79,7 +79,7 @@ public class SecUtilTest {
         Path path = Path.of("./target/sec.xml");
         SettingsSecurity config = SecUtil.read(path);
         assertNotNull(config);
-        assertEquals(SecUtil.specVersion(), config.getModelVersion());
+        assertEquals("4.0", config.getModelVersion());
         assertEquals(StandardCharsets.UTF_8.name(), config.getModelEncoding());
         assertEquals("magic:mighty", config.getDefaultDispatcher());
         SecUtil.write(path, config, true);


### PR DESCRIPTION
A minor/major change in the latter does not necessarily imply a new settings security model.